### PR TITLE
add_campaigns_stream

### DIFF
--- a/tap_dynamics/discover.py
+++ b/tap_dynamics/discover.py
@@ -20,6 +20,7 @@ advanced_tables = [
     "activitypointers",
     "businessunits",
     "activityparties",
+    "campaigns"
 ]
 
 


### PR DESCRIPTION
<img width="866" alt="Screenshot 2024-03-18 at 15 35 25" src="https://github.com/dreamdata-io/tap-dynamics/assets/83180345/db65c776-21a8-400e-9665-58d9c5e00654">

We need this stream in order to map the campaignid_value in stages to the Source Campaign Name.