### PR TITLE
include missing parenthesis in filtering activitypointers

### DIFF
--- a/tap_dynamics/sync.py
+++ b/tap_dynamics/sync.py
@@ -97,14 +97,14 @@ def sync_stream(service, state, start_date, stream, mdata):
 
 def _sync_stream_incremental(service, entitycls, start):
     base_query = service.query(entitycls)
+    conditions = [
+        "activitytypecode eq 'phonecall'",
+        "activitytypecode eq 'appointment'",
+        "activitytypecode eq 'email'"
+    ]
+    filter_string = "({})".format(" or ".join(conditions))
     if entitycls.__odata_schema__["name"] == "activitypointer":
-        base_query = base_query.filter(
-            base_query.or_(
-                entitycls.activitytypecode == "phonecall",
-                entitycls.activitytypecode == "appointment",
-                entitycls.activitytypecode == "email",
-            )
-        )
+        base_query = base_query.filter(filter_string)
 
     base_query = base_query.order_by(getattr(entitycls, MODIFIED_DATE_FIELD).asc())
 


### PR DESCRIPTION
the issue is that before we were missing the parethesis here: filter=(activitytypecode eq 'phonecall' or activitytypecode eq 'appointment' or activitytypecode eq 'email')&$orderby=modifiedon asc

causing unexpected behaviour. I can't really explain why it is happening only for learnlight but i tested with the update and now we sync only the three types

Another issue is that it seems that we do not include any emails later in dataform so maybe we could stop syncing them
https://github.com/dreamdata-io/dataform-microsoft-dynamics/blob/fad34bcd0388bf952f1f592e4ee8d12ec6c663a0/includes/events.js#L43C2-L43C3