### PR TITLE
filter parties using paricipationtypemask

### DIFF
--- a/tap_dynamics/sync.py
+++ b/tap_dynamics/sync.py
@@ -70,6 +70,18 @@ def sync_stream(service, state, start_date, stream, mdata):
         LOGGER.info("{} - Syncing using full replication".format(stream.tap_stream_id))
 
         query = service.query(entitycls)
+        if stream.tap_stream_id == "activityparties":
+            activityparties_conditions = [
+                    "participationtypemask eq 1",
+                    "participationtypemask eq 2",
+                    "participationtypemask eq 3",
+                    "participationtypemask eq 4",
+                    "participationtypemask eq 5",
+                    "participationtypemask eq 6",
+                    "participationtypemask eq 7",
+                ]
+            filter_activityparties = "({})".format(" or ".join(activityparties_conditions))
+            query = query.filter(filter_activityparties)
 
     schema = stream.schema.to_dict()
 
@@ -97,17 +109,19 @@ def sync_stream(service, state, start_date, stream, mdata):
 
 def _sync_stream_incremental(service, entitycls, start):
     base_query = service.query(entitycls)
-    conditions = [
-        "activitytypecode eq 'phonecall'",
-        "activitytypecode eq 'appointment'",
-        "activitytypecode eq 'email'"
-    ]
-    filter_string = "({})".format(" or ".join(conditions))
+
     if entitycls.__odata_schema__["name"] == "activitypointer":
-        base_query = base_query.filter(filter_string)
+        print("entered the activitypointer")
+        activitypointer_conditions = [
+            "activitytypecode eq 'phonecall'",
+            "activitytypecode eq 'appointment'",
+            "activitytypecode eq 'email'"
+        ]
+        filter_activitypointers = "({})".format(" or ".join(activitypointer_conditions))
+        base_query = base_query.filter(filter_activitypointers)
 
     base_query = base_query.order_by(getattr(entitycls, MODIFIED_DATE_FIELD).asc())
-
+    
     now = datetime.utcnow().replace(tzinfo=pytz.UTC)
     delta = timedelta(days=30)
 


### PR DESCRIPTION
Microsoft Link for Activity Entitites: https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/activityparty-entity?view=op-9-1#activity-party-types

![Screenshot 2025-01-20 at 12 49 52](https://github.com/user-attachments/assets/a1832d7a-24d6-4992-ae19-4d9f08334f72)
![Screenshot 2025-01-20 at 12 49 08](https://github.com/user-attachments/assets/3615ac71-9cb6-4825-a2fa-5ec49b867255)
![Screenshot 2025-01-20 at 12 47 28](https://github.com/user-attachments/assets/d01db4cf-d406-42f9-9d10-7cf4c3b9348d)

We can see from the screenshots above that in the three pointers we use (emails, appointments, phone calls) only parties with participationtypemask 1-7 are used and so we filter out the rest.

We expect this to be an improvement in syncing duration since we have too many data from other participation type masks
![Screenshot 2025-01-20 at 12 52 33](https://github.com/user-attachments/assets/15405788-798c-4673-ad4f-5c78239348c1)
